### PR TITLE
Release/stanpath v1 0 1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
updated github actions cache to be v4 as previous versions are depreccated.